### PR TITLE
Add cross‑compile fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-in the works 💪⚒ 
+# SvgScreenshot_v2
+
+This is a small experiment for capturing and displaying a screenshot using the Windows API.
+
+## Building
+
+This project targets Windows and requires the Windows SDK. On Debian-based systems you can install a MinGW toolchain and the SDK headers by running the helper script:
+
+```bash
+./setup.sh
+```
+
+After the dependencies are installed, compile with the MinGW cross compiler:
+
+```bash
+x86_64-w64-mingw32-g++ src/*.cpp -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -o screenshot.exe
+```
+
+Note that compilation on non-Windows hosts requires a cross compiler such as `mingw-w64`.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Simple helper to install a MinGW toolchain on Debian-based systems
+# Allows building the project with g++ on non-Windows hosts
+
+set -e
+
+if ! command -v apt-get >/dev/null; then
+  echo "apt-get not available. Install a MinGW-w64 toolchain manually." >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y mingw-w64 g++
+
+echo "Toolchain installed. You can now build with g++ src/*.cpp -o screenshot.exe"

--- a/src/displayWindow.cpp
+++ b/src/displayWindow.cpp
@@ -1,11 +1,11 @@
 #define _WIN32_WINNT 0x0603  // Windows 8.1 or later
 
-#include <ShellScalingApi.h>
-#include <Windows.h>
+#include <windows.h>
 
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <utility>
 
 #include "displayWindow.h"
 
@@ -95,7 +95,8 @@ LRESULT CALLBACK ScreenShotWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
         case WM_LBUTTONUP: {
             isDragging = false;
             GetCursorPos(&rectEnd);
-            InvalidateRect(hwnd, NULL, false);
+            InvalidateRect(hwnd, NULL, FALSE);
+            return 0;
         }
         case WM_SETCURSOR: {
             // set cursor to cross

--- a/src/displayWindow.h
+++ b/src/displayWindow.h
@@ -1,10 +1,11 @@
 #ifndef DISWIN_h
 #define DISWIN_h
 
-#include <Windows.h>
+#include <windows.h>
 
 #include <chrono>
 #include <thread>
+#include <utility>
 
 
 std::pair<double, double> getScalingFactors();
@@ -13,5 +14,11 @@ LRESULT CALLBACK ScreenShotWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
 
 void displayBitmap();
 
-void captureScreenToBitmap(HBITMAP *hBitmap) {
-#endif
+// Captures the contents of the primary screen into the given bitmap.
+void captureScreenToBitmap(HBITMAP *hBitmap);
+
+// handle to the bitmap that stores the screenshot. Defined in
+// displayWindow.cpp so that it can be used by multiple translation units.
+extern HBITMAP screenBitmap;
+
+#endif  // DISWIN_h

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,14 @@
-#include <ShellScalingApi.h>
-#include <Windows.h>
+#include <windows.h>
 
 #include "displayWindow.h"
 
 
 int main() {
-    // make the application DPI (Dot Per Inch) aware
-    // basically make windows provide the actual physical dimension of the screen to the program,
-    // instead of virtual dimensions caused by scaling
-    SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+    // Make the application DPI aware so that Windows provides physical
+    // screen dimensions instead of virtual ones caused by scaling.
+    // SetProcessDPIAware is widely supported and avoids a dependency on
+    // the ShellScalingApi header when cross-compiling.
+    SetProcessDPIAware();
     captureScreenToBitmap(&screenBitmap);
     displayBitmap();
 


### PR DESCRIPTION
## Summary
- fix header case sensitivity for MinGW
- drop ShellScalingApi dependency by using SetProcessDPIAware
- document cross compiler usage

## Testing
- `x86_64-w64-mingw32-g++ src/*.cpp -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -o screenshot.exe`

------
https://chatgpt.com/codex/tasks/task_e_6859bb5a117c83288083c5e7958d603d