### PR TITLE
Implement screen capture to clipboard

### DIFF
--- a/src/displayWindow.cpp
+++ b/src/displayWindow.cpp
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <thread>
 #include <utility>
+#include <algorithm>
+#include <cstdlib>
 
 #include "displayWindow.h"
 
@@ -96,6 +98,8 @@ LRESULT CALLBACK ScreenShotWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             isDragging = false;
             GetCursorPos(&rectEnd);
             InvalidateRect(hwnd, NULL, FALSE);
+            copySelectionToClipboard(rectStart, rectEnd);
+            PostQuitMessage(0);
             return 0;
         }
         case WM_SETCURSOR: {
@@ -207,4 +211,39 @@ void captureScreenToBitmap(HBITMAP *hBitmap) {
     // Cleanup
     DeleteDC(hdcMemory);
     ReleaseDC(NULL, hdcScreen);
+}
+
+// Copies the selected area from the global screenBitmap to the clipboard.
+void copySelectionToClipboard(POINT start, POINT end) {
+    int left = std::min(start.x, end.x);
+    int top = std::min(start.y, end.y);
+    int width = std::abs(end.x - start.x);
+    int height = std::abs(end.y - start.y);
+    if (width == 0 || height == 0) {
+        return;
+    }
+
+    HDC hdcScreen = GetDC(NULL);
+    HDC hdcSrc = CreateCompatibleDC(hdcScreen);
+    HBITMAP hOldSrc = (HBITMAP)SelectObject(hdcSrc, screenBitmap);
+
+    HDC hdcDst = CreateCompatibleDC(hdcScreen);
+    HBITMAP hbmCrop = CreateCompatibleBitmap(hdcScreen, width, height);
+    HBITMAP hOldDst = (HBITMAP)SelectObject(hdcDst, hbmCrop);
+
+    BitBlt(hdcDst, 0, 0, width, height, hdcSrc, left, top, SRCCOPY);
+
+    SelectObject(hdcSrc, hOldSrc);
+    SelectObject(hdcDst, hOldDst);
+    DeleteDC(hdcSrc);
+    DeleteDC(hdcDst);
+    ReleaseDC(NULL, hdcScreen);
+
+    if (OpenClipboard(NULL)) {
+        EmptyClipboard();
+        SetClipboardData(CF_BITMAP, hbmCrop);
+        CloseClipboard();
+    } else {
+        DeleteObject(hbmCrop);
+    }
 }

--- a/src/displayWindow.h
+++ b/src/displayWindow.h
@@ -21,4 +21,7 @@ void captureScreenToBitmap(HBITMAP *hBitmap);
 // displayWindow.cpp so that it can be used by multiple translation units.
 extern HBITMAP screenBitmap;
 
+// Copies the selected area of the screen bitmap to the clipboard.
+void copySelectionToClipboard(POINT start, POINT end);
+
 #endif  // DISWIN_h


### PR DESCRIPTION
## Summary
- capture the screen area selected with the red box
- copy the cropped bitmap to the clipboard when the mouse is released

## Testing
- `./setup.sh`
- `x86_64-w64-mingw32-g++ src/*.cpp -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -o screenshot.exe`

------
https://chatgpt.com/codex/tasks/task_e_6859ca9917888328a04b87aed160c27a