### PR TITLE
Improve selection overlay visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project targets Windows and requires the Windows SDK. On Debian-based syste
 After the dependencies are installed, compile with the MinGW cross compiler:
 
 ```bash
-x86_64-w64-mingw32-g++ src/*.cpp -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -o screenshot.exe
+x86_64-w64-mingw32-g++ src/*.cpp -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -lmsimg32 -o screenshot.exe
 ```
 
 Note that compilation on non-Windows hosts requires a cross compiler such as `mingw-w64`.

--- a/src/displayWindow.cpp
+++ b/src/displayWindow.cpp
@@ -1,13 +1,14 @@
 #define _WIN32_WINNT 0x0603  // Windows 8.1 or later
 
+#include "displayWindow.h"
+
 #include <windows.h>
 
+#include <algorithm>
 #include <chrono>
 #include <iostream>
 #include <thread>
 #include <utility>
-
-#include "displayWindow.h"
 
 HBITMAP screenBitmap;  // global bitmap handle; stores screenshot
 
@@ -58,22 +59,47 @@ LRESULT CALLBACK ScreenShotWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             // Draw the bitmap onto the window
             BitBlt(hdc, 0, 0, bitmap.bmWidth, bitmap.bmHeight, hdcMemory, 0, 0, SRCCOPY);
 
-            // Cleanup
-            SelectObject(hdcMemory, hOldBitmap);
-            DeleteDC(hdcMemory);
+            // Create a semi-transparent overlay to darken the entire screen
+            HDC hdcOverlay = CreateCompatibleDC(hdc);
+            HBITMAP hOverlayBitmap =
+                CreateCompatibleBitmap(hdc, bitmap.bmWidth, bitmap.bmHeight);
+            HBITMAP hOldOverlayBitmap = (HBITMAP)SelectObject(hdcOverlay, hOverlayBitmap);
+            HBRUSH hBrush = CreateSolidBrush(RGB(0, 0, 0));
+            RECT fullRect = {0, 0, bitmap.bmWidth, bitmap.bmHeight};
+            FillRect(hdcOverlay, &fullRect, hBrush);
 
-            // Draw the red rectangle if dragging
+            BLENDFUNCTION blend = {AC_SRC_OVER, 0, 128, 0};  // 50% opacity
+            AlphaBlend(hdc, 0, 0, bitmap.bmWidth, bitmap.bmHeight, hdcOverlay, 0, 0,
+                       bitmap.bmWidth, bitmap.bmHeight, blend);
+
             if (isDragging) {
-                HPEN hPen = CreatePen(PS_SOLID, 1, RGB(255, 0, 0));  // Red pen
+                // Normalize the rectangle coordinates in case the user drags in any direction
+                int left = std::min(rectStart.x, rectEnd.x);
+                int top = std::min(rectStart.y, rectEnd.y);
+                int right = std::max(rectStart.x, rectEnd.x);
+                int bottom = std::max(rectStart.y, rectEnd.y);
+
+                // Restore the screenshot brightness in the selected area
+                BitBlt(hdc, left, top, right - left, bottom - top, hdcMemory, left, top, SRCCOPY);
+
+                // Draw the red rectangle outline
+                HPEN hPen = CreatePen(PS_SOLID, 1, RGB(255, 0, 0));
                 HGDIOBJ hOldPen = SelectObject(hdc, hPen);
-                HGDIOBJ hOldBrush = SelectObject(hdc, GetStockObject(NULL_BRUSH));  // No fill
-
-                Rectangle(hdc, rectStart.x, rectStart.y, rectEnd.x, rectEnd.y);
-
+                HGDIOBJ hOldBrush = SelectObject(hdc, GetStockObject(NULL_BRUSH));
+                Rectangle(hdc, left, top, right, bottom);
                 SelectObject(hdc, hOldPen);
                 SelectObject(hdc, hOldBrush);
                 DeleteObject(hPen);
             }
+
+            // Cleanup overlay and memory DC resources
+            SelectObject(hdcOverlay, hOldOverlayBitmap);
+            DeleteObject(hOverlayBitmap);
+            DeleteObject(hBrush);
+            DeleteDC(hdcOverlay);
+
+            SelectObject(hdcMemory, hOldBitmap);
+            DeleteDC(hdcMemory);
 
             EndPaint(hwnd, &ps);
             return 0;

--- a/src/displayWindow.cpp
+++ b/src/displayWindow.cpp
@@ -48,7 +48,7 @@ LRESULT CALLBACK ScreenShotWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             PAINTSTRUCT ps;
             HDC hdc = BeginPaint(hwnd, &ps);
 
-            // Create a memory DC and select the bitmap into it
+            // Create a memory DC for the screenshot
             HDC hdcMemory = CreateCompatibleDC(hdc);
             HBITMAP hOldBitmap = (HBITMAP)SelectObject(hdcMemory, screenBitmap);
 
@@ -56,8 +56,13 @@ LRESULT CALLBACK ScreenShotWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             BITMAP bitmap;
             GetObject(screenBitmap, sizeof(BITMAP), &bitmap);
 
-            // Draw the bitmap onto the window
-            BitBlt(hdc, 0, 0, bitmap.bmWidth, bitmap.bmHeight, hdcMemory, 0, 0, SRCCOPY);
+            // Create an off-screen buffer to avoid flicker when redrawing
+            HDC hdcBuffer = CreateCompatibleDC(hdc);
+            HBITMAP hBufferBitmap = CreateCompatibleBitmap(hdc, bitmap.bmWidth, bitmap.bmHeight);
+            HBITMAP hOldBufferBitmap = (HBITMAP)SelectObject(hdcBuffer, hBufferBitmap);
+
+            // Draw the screenshot into the buffer first
+            BitBlt(hdcBuffer, 0, 0, bitmap.bmWidth, bitmap.bmHeight, hdcMemory, 0, 0, SRCCOPY);
 
             // Create a semi-transparent overlay to darken the entire screen
             HDC hdcOverlay = CreateCompatibleDC(hdc);
@@ -69,7 +74,7 @@ LRESULT CALLBACK ScreenShotWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             FillRect(hdcOverlay, &fullRect, hBrush);
 
             BLENDFUNCTION blend = {AC_SRC_OVER, 0, 128, 0};  // 50% opacity
-            AlphaBlend(hdc, 0, 0, bitmap.bmWidth, bitmap.bmHeight, hdcOverlay, 0, 0,
+            AlphaBlend(hdcBuffer, 0, 0, bitmap.bmWidth, bitmap.bmHeight, hdcOverlay, 0, 0,
                        bitmap.bmWidth, bitmap.bmHeight, blend);
 
             if (isDragging) {
@@ -80,23 +85,30 @@ LRESULT CALLBACK ScreenShotWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
                 int bottom = std::max(rectStart.y, rectEnd.y);
 
                 // Restore the screenshot brightness in the selected area
-                BitBlt(hdc, left, top, right - left, bottom - top, hdcMemory, left, top, SRCCOPY);
+                BitBlt(hdcBuffer, left, top, right - left, bottom - top, hdcMemory, left, top, SRCCOPY);
 
                 // Draw the red rectangle outline
                 HPEN hPen = CreatePen(PS_SOLID, 1, RGB(255, 0, 0));
-                HGDIOBJ hOldPen = SelectObject(hdc, hPen);
-                HGDIOBJ hOldBrush = SelectObject(hdc, GetStockObject(NULL_BRUSH));
-                Rectangle(hdc, left, top, right, bottom);
-                SelectObject(hdc, hOldPen);
-                SelectObject(hdc, hOldBrush);
+                HGDIOBJ hOldPen = SelectObject(hdcBuffer, hPen);
+                HGDIOBJ hOldBrush = SelectObject(hdcBuffer, GetStockObject(NULL_BRUSH));
+                Rectangle(hdcBuffer, left, top, right, bottom);
+                SelectObject(hdcBuffer, hOldPen);
+                SelectObject(hdcBuffer, hOldBrush);
                 DeleteObject(hPen);
             }
 
-            // Cleanup overlay and memory DC resources
+            // Copy the composed buffer to the window in one operation
+            BitBlt(hdc, 0, 0, bitmap.bmWidth, bitmap.bmHeight, hdcBuffer, 0, 0, SRCCOPY);
+
+            // Cleanup
             SelectObject(hdcOverlay, hOldOverlayBitmap);
             DeleteObject(hOverlayBitmap);
             DeleteObject(hBrush);
             DeleteDC(hdcOverlay);
+
+            SelectObject(hdcBuffer, hOldBufferBitmap);
+            DeleteObject(hBufferBitmap);
+            DeleteDC(hdcBuffer);
 
             SelectObject(hdcMemory, hOldBitmap);
             DeleteDC(hdcMemory);


### PR DESCRIPTION
## Summary
- darken the full screen with a semi-transparent overlay
- brighten the selected region so the rectangle stands out
- link with `msimg32` in the build instructions

## Testing
- `./setup.sh`
- `x86_64-w64-mingw32-g++ src/*.cpp -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -lmsimg32 -o screenshot.exe`


------
https://chatgpt.com/codex/tasks/task_e_6859caf275048328a5199fd72b2de3ce