### PR TITLE
Add Makefile for simple build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake
-Makefile
 
 # Ignore compiled object files and binaries
 *.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CXX ?= x86_64-w64-mingw32-g++
+CXXFLAGS ?= -std=c++17 -Wall -O2
+LDFLAGS = -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -lmsimg32
+
+SRC_DIR := src
+SRCS := $(wildcard $(SRC_DIR)/*.cpp)
+OBJS := $(SRCS:.cpp=.o)
+TARGET := screenshot.exe
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CXX) $(OBJS) $(LDFLAGS) -o $@
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(TARGET)

--- a/README.md
+++ b/README.md
@@ -10,10 +10,19 @@ This project targets Windows and requires the Windows SDK. On Debian-based syste
 ./setup.sh
 ```
 
-After the dependencies are installed, compile with the MinGW cross compiler:
+After the dependencies are installed, build the project using the provided
+`Makefile`:
+
+```bash
+make
+```
+
+This will produce `screenshot.exe` in the repository root. If you prefer to
+invoke the compiler manually, use:
 
 ```bash
 x86_64-w64-mingw32-g++ src/*.cpp -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -lmsimg32 -o screenshot.exe
 ```
 
-Note that compilation on non-Windows hosts requires a cross compiler such as `mingw-w64`.
+Note that compilation on non-Windows hosts still requires a cross compiler such
+as `mingw-w64`.


### PR DESCRIPTION
## Summary
- remove Makefile from `.gitignore` and add a simple build script
- document the new `make` workflow in the README

## Testing
- `make` *(fails: windows headers not present)*

------
https://chatgpt.com/codex/tasks/task_e_6859d176c3788328b6b475bc85f425f5