### PR TITLE
Add FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ Thumbs.db
 # Ignore todo list files
 /todo/
 *.todo
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/

--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ x86_64-w64-mingw32-g++ src/*.cpp -lgdi32 -lole32 -luuid -lcomdlg32 -lshell32 -lm
 
 Note that compilation on non-Windows hosts still requires a cross compiler such
 as `mingw-w64`.
+
+## FastAPI backend
+
+This repository also includes a small FastAPI application for storing screenshot metadata in MongoDB. The server exposes two endpoints to create and list screenshots.
+
+### Running
+
+Install the Python dependencies and start the server with Uvicorn:
+
+```bash
+pip install -r requirements.txt
+MONGO_URI="<your mongodb atlas uri>" uvicorn backend.main:app --reload
+```
+
+The API uses a collection called `screenShots` in the database specified by the `MONGO_DB_NAME` environment variable (defaults to `screenshots_db`).

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from typing import Optional, List
+from datetime import datetime
+from pymongo import MongoClient
+from bson.objectid import ObjectId
+import os
+
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+DB_NAME = os.getenv("MONGO_DB_NAME", "screenshots_db")
+client = MongoClient(MONGO_URI)
+db = client[DB_NAME]
+collection = db["screenShots"]
+
+app = FastAPI()
+
+class ScreenshotCreate(BaseModel):
+    image_url: str
+    date_taken: datetime = Field(default_factory=datetime.utcnow)
+    description: Optional[str] = None
+
+class Screenshot(ScreenshotCreate):
+    id: str
+
+
+def serialize(doc) -> Screenshot:
+    return Screenshot(
+        id=str(doc["_id"]),
+        image_url=doc["image_url"],
+        date_taken=doc["date_taken"],
+        description=doc.get("description"),
+    )
+
+@app.post("/screenshots", response_model=Screenshot)
+def create_screenshot(data: ScreenshotCreate):
+    result = collection.insert_one(data.dict())
+    doc = collection.find_one({"_id": result.inserted_id})
+    if not doc:
+        raise HTTPException(status_code=500, detail="Failed to create screenshot")
+    return serialize(doc)
+
+@app.get("/screenshots", response_model=List[Screenshot])
+def list_screenshots():
+    return [serialize(doc) for doc in collection.find()]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+pymongo


### PR DESCRIPTION
## Summary
- implement `backend/main.py` with FastAPI and MongoDB logic
- include `requirements.txt`
- update `.gitignore` for Python artifacts
- document FastAPI server usage in README

## Testing
- `pip install -q -r requirements.txt`
- `python3 -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6859e4cd620c832883a8001d615dee49