### PR TITLE
Improve Electron viewer with React

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ as `mingw-w64`.
 Captured selections are now written to the `screenshots` directory in the
 repository root. Each file is saved as `screenshot_<timestamp>.bmp`.
 
-An example Electron application lives in `electron-app`. It lists the images in
-the screenshots folder and displays them. Run it after installing dependencies
-with:
+An example Electron application lives in `electron-app`. It now uses a small
+React interface that shows each screenshot in a fixed size card with a button to
+copy the image to your clipboard. Run it after installing dependencies with:
 
 ```bash
 cd electron-app

--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -3,10 +3,19 @@
 <head>
   <meta charset="UTF-8">
   <title>Screenshots</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      padding: 20px;
+    }
+  </style>
 </head>
 <body>
-  <h1>Screenshots</h1>
-  <div id="images"></div>
-  <script src="renderer.js"></script>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="renderer.js" type="text/babel"></script>
 </body>
 </html>

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -1,15 +1,35 @@
-const { ipcRenderer } = require('electron');
+const { ipcRenderer, clipboard, nativeImage } = require('electron');
+const path = require('path');
 
-window.addEventListener('DOMContentLoaded', () => {
-  ipcRenderer.on('file-list', (_event, files) => {
-    const container = document.getElementById('images');
-    files.forEach(file => {
-      const img = document.createElement('img');
-      img.src = file;
-      img.style.maxWidth = '100%';
-      img.style.display = 'block';
-      img.style.marginBottom = '10px';
-      container.appendChild(img);
+function ImageCard({ file }) {
+  const copyToClipboard = () => {
+    const absPath = path.resolve(__dirname, file);
+    const img = nativeImage.createFromPath(absPath);
+    clipboard.writeImage(img);
+  };
+
+  return (
+    <div style={{border: '1px solid #ccc', width: '200px', height: '200px', margin: '10px', padding: '10px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'space-between'}}>
+      <img src={file} style={{maxWidth: '100%', maxHeight: '150px', objectFit: 'contain'}} />
+      <button onClick={copyToClipboard}>Copy</button>
+    </div>
+  );
+}
+
+function App() {
+  const [files, setFiles] = React.useState([]);
+
+  React.useEffect(() => {
+    ipcRenderer.on('file-list', (_event, list) => {
+      setFiles(list);
     });
-  });
-});
+  }, []);
+
+  return (
+    <div style={{display: 'flex', flexWrap: 'wrap'}}>
+      {files.map(f => <ImageCard key={f} file={f} />)}
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- integrate React in `electron-app`
- show screenshots in card layout with Copy button
- document updated React UI

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685ac72864a88328b1414503887a65b2